### PR TITLE
Update TransformEvaluator.ts to include decomposeDiacriticalMarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This changelog is following the recommended format by [keepachangelog](https://k
 
 ## [Unreleased]
 
+## [1.3.3] - 2024-09-19
+
+### Added
+
+- Added transform evaluation support for `decomposeDiacriticalMarks` (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)
+
 ## [1.3.2] - 2024-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This changelog is following the recommended format by [keepachangelog](https://k
 
 ### Added
 
-- Added transform evaluation support for `decomposeDiacriticalMarks` (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)
+- Added transform evaluation support for `decomposeDiacriticalMarks` (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)) by [@Semperverus](https://github.com/Semperverus) 
 
 ## [1.3.2] - 2024-07-03
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ The patterns defined above use the following tokens:
 
 ## 1.3.3
 
-- Added support for `decomposeDiacriticalMarks` transform evaluation (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)
+- Added support for `decomposeDiacriticalMarks` transform evaluation (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)) by [@Semperverus](https://github.com/Semperverus)
 
 ## 1.3.2
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ The patterns defined above use the following tokens:
 
 ## Release Notes
 
+## 1.3.3
+
+- Added support for `decomposeDiacriticalMarks` transform evaluation (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)
+
 ## 1.3.2
 
 - Updated schema for lifefycle state (`identityState`)

--- a/src/services/TransformEvaluator.ts
+++ b/src/services/TransformEvaluator.ts
@@ -276,6 +276,9 @@ export class TransformEvaluator {
             case 'dateFormat':
                 result = await this.dateFormat(attributes);
                 break;
+            case 'decomposeDiacriticalMarks':
+                result = await this.decomposeDiacriticalMarks(attributes);
+                break;
             case 'e164phone':
                 result = await this.e164phone(attributes);
                 break;
@@ -898,6 +901,32 @@ export class TransformEvaluator {
         }
 
         console.log("Exiting dateFormat. result=" + result);
+        return result;
+    }
+
+    async decomposeDiacriticalMarks(attributes: any) {
+        console.log("Entering method decomposeDiacriticalMarks");
+        let result = undefined;
+
+        let input = this.input;
+
+        if (input === undefined) {
+            if (attributes.input !== undefined) {
+                input = attributes.input;
+
+                if (typeof input === 'object') {
+                    input = await this.evaluateChildTransform(input);
+                }
+
+                if (input === undefined) {
+                    return;
+                }
+            }
+        }
+
+        result = input.normalize('NFD').replace(/[\u0300-\u036f]/g, "");
+
+        console.log("Exiting decomposeDiacriticalMarks. result=" + result);
         return result;
     }
 

--- a/src/services/TransformEvaluator.ts
+++ b/src/services/TransformEvaluator.ts
@@ -924,7 +924,7 @@ export class TransformEvaluator {
             }
         }
 
-        result = input.normalize('NFD').replace(/[\u0300-\u036f]/g, "");
+        result = input.normalize('NFKD').replace(/[\u0300-\u036f]/g, "");
 
         console.log("Exiting decomposeDiacriticalMarks. result=" + result);
         return result;

--- a/src/test/unit/decomposeDiacriticalMarks.test.ts
+++ b/src/test/unit/decomposeDiacriticalMarks.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import { it, describe } from 'mocha';
+import { toCamelCase } from '../../utils/stringUtils';
+
+suite('decomposeDiacriticalMarks Test Suite', () => {
+	// vscode.window.showInformationMessage('Start all tests.');
+	describe('decomposeDiacriticalMarks', () => {
+		const tests = [
+			{ args: 'Āric', expected: 'Aric' },
+			{ args: 'Dubçek', expected: 'Dubcek' },
+			{ args: 'Amélie', expected: 'Amelie' },
+			{ args: "àáâãäåçèéêëìíîïñòóôõöùúûüýÿ", expected: 'aaaaaaceeeeiiiinooooouuuuyy' },
+		];
+		tests.forEach(({ args, expected }) => {
+			it(`should correctly format ${args}`, () => {
+				const result = decomposeDiacriticalMarks(args);
+				assert.strictEqual(result, expected);
+			});
+		});
+	});
+
+});

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -49,3 +49,11 @@ export function toCamelCase(input: string): string {
         return word;
     }).join('');
 }
+
+export function decomposeDiacriticalMarks(input: string): string {
+    return input
+        // Decompose the string into separate unicode symbols for diacritical marks in compatibility mode, 
+        .normalize('NFKD')
+        // Remove the unicode diacritical marks.
+        .replace(/[\u0300-\u036f]/g, "");
+}


### PR DESCRIPTION
Adds a very rudimentary decomposeDiacriticalMarks function to the Transform Evaluators.

The way this functions is by using the built-in javascript `normalize()` method in 'NFKD' mode to first break a character with diacritical marks up into its constituent unicode components in compatibility mode, and then it performs a regex `.replace()` to strip out the diacritical marks in the string. These diacritical marks are located in unicode range `\u0300` through `\u036F` as referenced in the [official unicode documenation](https://www.unicode.org/charts/PDF/U0300.pdf) (or alternatively the [Wikipedia page](https://en.wikipedia.org/wiki/Combining_Diacritical_Marks) which is much easier to read)

This code requires testing within the plugin itself, but the function to perform the decomposition has been tested independently.

[Official SailPoint Developer documenation page for decomposeDiacriticalMarks](https://developer.sailpoint.com/docs/extensibility/transforms/operations/decompose-diacritical-marks/)
