### PR TITLE
Authentication provider refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This changelog is following the recommended format by [keepachangelog](https://k
 
 ### Removed
 
+## [1.3.4] - 2024-10-12
+
+### Fixed
+
+- Fix authentication provider multi account support (as part of [VSCode September's release](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference)) (cf. [#94](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/94))
+
 ## [1.3.3] - 2024-10-09
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -304,6 +304,12 @@ The patterns defined above use the following tokens:
 
 ## Release Notes
 
+## 1.3.4
+
+- Fix authentication provider multi account support (as part of [VSCode September's release](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference)) (cf. [#94](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/94))
+
+## 1.3.3
+
 - Add User Agent
 - Add transform evaluation support for `decomposeDiacriticalMarks` (cf. [#90](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/90)) by [@Semperverus](https://github.com/Semperverus)
 - Add new command to enable logging
@@ -312,7 +318,6 @@ The patterns defined above use the following tokens:
 - Removed Workflow Tester view due to webview-ui-toolkit deprecation (cf. https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561)
 - Add support for Applications
 - Error with session management (cf. [#93](https://github.com/yannick-beot-sp/vscode-sailpoint-identitynow/issues/93))
-
 
 ## 1.3.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-sailpoint-identitynow",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-sailpoint-identitynow",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -1461,13 +1461,7 @@
           "default": 100
         }
       }
-    },
-    "authentication": [
-      {
-        "id": "SailPointIdentityNowPAT",
-        "label": "SailPoint Identity Now"
-      }
-    ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sailpoint-identitynow",
   "displayName": "SailPoint Identity Security Cloud",
   "description": "Customize SailPoint Identity Security Cloud",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "publisher": "yannick-beot-sp",
   "icon": "resources/isc.png",
   "bugs": {

--- a/src/commands/addTenant.ts
+++ b/src/commands/addTenant.ts
@@ -84,10 +84,8 @@ export class AddTenantCommand {
             readOnly: true
         });
         try {
-            const session: vscode.AuthenticationSession = await vscode.authentication.getSession(
-                SailPointISCAuthenticationProvider.id,
-                [tenantId],
-                { createIfNone: true });
+            const session = await SailPointISCAuthenticationProvider.getInstance().createSession(tenantId)
+
             if (session !== undefined && !isEmpty(session.accessToken)) {
                 await vscode.commands.executeCommand(commands.REFRESH_FORCED);
                 await vscode.window.showInformationMessage(`Tenant ${displayName} added!`);

--- a/src/services/AuthenticationProvider.ts
+++ b/src/services/AuthenticationProvider.ts
@@ -1,12 +1,4 @@
 import {
-    authentication,
-    AuthenticationProvider,
-    AuthenticationProviderAuthenticationSessionsChangeEvent,
-    AuthenticationSession,
-    AuthenticationSessionAccountInformation,
-    Disposable,
-    Event,
-    EventEmitter,
     window,
 } from 'vscode';
 import { AuthenticationMethod, TenantCredentials, TenantToken } from '../models/TenantInfo';
@@ -16,127 +8,88 @@ import { EndpointUtils } from '../utils/EndpointUtils';
 import { TenantService } from './TenantService';
 import { OAuth2Client } from './OAuth2Client';
 
-class SailPointISCPatSession implements AuthenticationSession {
-    readonly account: AuthenticationSessionAccountInformation;
-    // No scope management for now
-    readonly scopes = [];
-
+class SailPointISCPatSession {
     /**
      * 
-     * @param tenantName The tenant name
-     * @param clientId The client ID of the PAT
      * @param accessToken The personal access token to use for authentication
-     * 
      */
-    constructor(tenantName: string,
-        clientId: string,
+    constructor(
         public readonly accessToken: string,
-        public readonly id: string
-
-    ) {
-        this.account = { id: clientId, label: `Personal Access Token for ${tenantName}` };
-    }
+    ) { }
 }
 
-export class SailPointISCAuthenticationProvider implements AuthenticationProvider, Disposable {
-
-
-    static id = 'SailPointIdentityNowPAT';
-
-
-    // this property is used to determine if the token has been changed in another window of VS Code.
-    // It is used in the checkForUpdates function.
-    private currentToken: Promise<string | undefined> | undefined;
-    private initializedDisposable: Disposable | undefined;
-
-    private _onDidChangeSessions = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
-    get onDidChangeSessions(): Event<AuthenticationProviderAuthenticationSessionsChangeEvent> {
-        return this._onDidChangeSessions.event;
-    }
-
-    constructor(private readonly tenantService: TenantService) { }
-
-    dispose(): void {
-        this.initializedDisposable?.dispose();
-    }
-
-    private ensureInitialized(): void {
-        if (this.initializedDisposable === undefined) {
-
-            this.initializedDisposable = Disposable.from(
-                // This onDidChange event happens when the secret storage changes in _any window_ since
-                // secrets are shared across all open windows.
-                // this.secretStorage.onDidChange(e => {
-                //     if (e.key.startsWith(SailPointIdentityNowAuthenticationProvider.SECRET_AT_PREFIX)
-                //         || e.key.startsWith(SailPointIdentityNowAuthenticationProvider.SECRET_PAT_PREFIX)) {
-                //         //void this.checkForUpdates();
-                //     }
-                // }),
-                // This fires when the user initiates a "silent" auth flow via the Accounts menu.
-                authentication.onDidChangeSessions(e => {
-                    if (e.provider.id === SailPointISCAuthenticationProvider.id) {
-                        //void this.checkForUpdates();
-                    }
-                }),
-            );
-        }
-    }
-
-    /**
-     *This is a crucial function that handles whether or not the token has changed in
-     *a different window of VS Code and sends the necessary event if it has.
-     */
-    private async checkForUpdates(): Promise<void> {
-        const added: AuthenticationSession[] = [];
-        const removed: AuthenticationSession[] = [];
-        const changed: AuthenticationSession[] = [];
-
-        const previousToken = await this.currentToken;
-        /*
-        const session = (await this.getSessions())[0];
-
-        if (session?.accessToken && !previousToken) {
-            added.push(session);
-        } else if (!session?.accessToken && previousToken) {
-            removed.push(session);
-        } else if (session?.accessToken !== previousToken) {
-            changed.push(session);
-        } else {
-            return;
-        }
-
-        this._onDidChangeSessions.fire({ added: added, removed: removed, changed: changed });
-        */
-    }
-
-
-    private async getTenants(): Promise<string[]> {
-        return (await this.tenantService.getTenants()).map(t => t.id);
-    }
-
-    /**
-     * This function is called first when `vscode.authentication.getSessions` is called.
-     */
-    async getSessions(_scopes?: string[]): Promise<readonly AuthenticationSession[]> {
-        console.log("> getSessions", _scopes);
-        this.ensureInitialized();
-        const result: SailPointISCPatSession[] = [];
-        if (_scopes === undefined || _scopes.length === 0) {
-            // return all scopes
-            _scopes = await this.getTenants();
-        }
-        for (let index = 0; index < _scopes.length; index++) {
-            const tenantId = _scopes[index];
-            const session = await this.getSessionByTenant(tenantId);
-            if (session !== null) {
-                result.push(session);
+async function askPATClientId(): Promise<string | undefined> {
+    const result = await window.showInputBox({
+        value: '',
+        ignoreFocusOut: true,
+        placeHolder: '806c451e057b442ba67b5d459716e97a',
+        prompt: 'Enter a Personal Access Token (PAT) Client ID.',
+        title: 'Identity Security Cloud',
+        validateInput: text => {
+            const regex = new RegExp('^[a-f0-9]{32}$');
+            if (regex.test(text)) {
+                return null;
             }
+            return "Invalid client ID";
         }
-        console.log("< getSessions");
-        return result;
+    });
+
+    return result;
+}
+
+async function askPATClientSecret(): Promise<string | undefined> {
+    const result = await window.showInputBox({
+        value: '',
+        password: true,
+        ignoreFocusOut: true,
+        placeHolder: '***',
+        prompt: 'Enter a Personal Access Token (PAT) Secret.',
+        title: 'Identity Security Cloud',
+        validateInput: text => {
+            const regex = new RegExp('^[a-f0-9]{63,64}$');
+            if (regex.test(text)) {
+                return null;
+            }
+            return "Invalid secret";
+        }
+    });
+    return result;
+}
+
+async function askAccessToken(): Promise<string | undefined> {
+    const result = await window.showInputBox({
+        value: '',
+        password: true,
+        ignoreFocusOut: true,
+        placeHolder: '***',
+        prompt: 'Enter an Access Token.',
+        title: 'Identity Security Cloud',
+        validateInput: text => {
+            const regex = new RegExp('^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_+/=-]+)$');
+            if (regex.test(text)) {
+                return null;
+            }
+            return "Invalid access token";
+        }
+    });
+    return result;
+}
+export class SailPointISCAuthenticationProvider {
+
+    private static instance: SailPointISCAuthenticationProvider
+
+
+    private constructor(private readonly tenantService: TenantService) { }
+
+    public static initialize(tenantService: TenantService) {
+        SailPointISCAuthenticationProvider.instance = new SailPointISCAuthenticationProvider(tenantService)
     }
 
-    private async getSessionByTenant(tenantId: string): Promise<SailPointISCPatSession | null> {
+    public static getInstance(): SailPointISCAuthenticationProvider {
+        return SailPointISCAuthenticationProvider.instance;
+    }
+
+    public async getSessionByTenant(tenantId: string): Promise<SailPointISCPatSession | null> {
         console.log("> getSessionByTenant", tenantId);
         // Check if an access token already exists
         let token = await this.tenantService.getTenantAccessToken(tenantId);
@@ -144,7 +97,7 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
         if (token === undefined || token.expired()) {
             console.log("INFO: accessToken is expired. Updating Access Token");
             if (tenantInfo?.authenticationMethod === AuthenticationMethod.accessToken) {
-                const accessToken = await this.askAccessToken() || "";
+                const accessToken = await askAccessToken() || "";
                 if (isEmpty(accessToken)) {
                     throw new Error('Access Token is required');
                 }
@@ -152,11 +105,7 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
                 const token = new TenantToken(accessToken, new Date(jwt.exp * 1000), { clientId: jwt.client_id } as TenantCredentials);
                 this.tenantService.setTenantAccessToken(tenantId, token);
 
-                return new SailPointISCPatSession(
-                    tenantInfo?.tenantName ?? "",
-                    jwt.client_id,
-                    accessToken,
-                    this.getSessionId(tenantId));
+                return new SailPointISCPatSession(accessToken)
             } else {
                 // If no access token or expired => create one
                 const credentials = await this.tenantService.getTenantCredentials(tenantId);
@@ -168,11 +117,7 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
                         this.tenantService.setTenantAccessToken(tenantId, token);
 
                         console.log("< getSessionByTenant for", tenantId);
-                        return new SailPointISCPatSession(tenantInfo?.tenantName ?? "",
-                            credentials.clientId,
-                            token.accessToken,
-                            this.getSessionId(tenantId)
-                        );
+                        return new SailPointISCPatSession(token.accessToken);
                     } catch (error) {
                         console.error(error);
                     }
@@ -183,11 +128,7 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
             }
         } else {
             console.log("< getSessionByTenant existing token");
-            return new SailPointISCPatSession(
-                tenantInfo?.tenantName ?? "",
-                token.client.clientId,
-                token.accessToken,
-                this.getSessionId(tenantId));
+            return new SailPointISCPatSession(token.accessToken)
         }
 
         console.log("< getSessionByTenant null");
@@ -195,43 +136,30 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
     }
 
     /**
-     * This function is called after `this.getSessions` is called and only when:
-     * - `this.getSessions` returns nothing but `createIfNone` was set to `true` in `vscode.authentication.getSessions`
-     * - `vscode.authentication.getSessions` was called with `forceNewSession: true`
-     * - The end user initiates the "silent" auth flow via the Accounts menu
+     * Collect info depending on the tenant authentication method and return a session
      */
-    async createSession(_scopes: string[]): Promise<AuthenticationSession> {
-        console.log("> createSession", _scopes);
-        if (_scopes.length !== 1 || isEmpty(_scopes[0])) {
-            throw new Error('Scope is required');
-        }
-        this.ensureInitialized();
-        const tenantId = _scopes[0];
+    async createSession(tenantId: string): Promise<SailPointISCPatSession> {
+        console.log("> createSession", tenantId);
         const tenantInfo = this.tenantService.getTenant(tenantId);
 
         if (tenantInfo?.authenticationMethod === AuthenticationMethod.accessToken) {
             // Access Token
-            const accessToken = await this.askAccessToken() || "";
+            const accessToken = await askAccessToken() || "";
             if (isEmpty(accessToken)) {
                 throw new Error('Access Token is required');
             }
             const jwt = parseJwt(accessToken);
             const token = new TenantToken(accessToken, new Date(jwt.exp * 1000), {} as TenantCredentials);
             this.tenantService.setTenantAccessToken(tenantId, token);
-            return new SailPointISCPatSession(
-                tenantInfo?.tenantName ?? "",
-                jwt.client_id,
-                accessToken,
-                this.getSessionId(tenantId));
-
+            return new SailPointISCPatSession(accessToken);
         } else {
             // Prompt for the PAT.
-            const clientId = await this.askPATClientId() || "";
+            const clientId = await askPATClientId() || "";
             if (isEmpty(clientId)) {
                 throw new Error('Client ID is required');
             }
 
-            const clientSecret = await this.askPATClientSecret() || "";
+            const clientSecret = await askPATClientSecret() || "";
             if (isEmpty(clientSecret)) {
                 throw new Error('Client Secret is required');
             }
@@ -243,11 +171,7 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
                     clientSecret: clientSecret
                 });
 
-            return new SailPointISCPatSession(
-                tenantInfo?.tenantName ?? "",
-                clientId,
-                token.accessToken,
-                this.getSessionId(tenantId));
+            return new SailPointISCPatSession(token.accessToken)
         }
     }
 
@@ -278,80 +202,14 @@ export class SailPointISCAuthenticationProvider implements AuthenticationProvide
         return token;
     }
 
-    private getSessionId(tenantId: string): string {
-        return SailPointISCAuthenticationProvider.id + '_' + tenantId;
-    }
-
-    private getTenantNameFromSessionId(sessionId: string) {
-        const regexp = new RegExp(SailPointISCAuthenticationProvider.id + '_' + '(.*)');
-        return sessionId.replace(regexp, "$1");
-    }
-
-
     // This function is called when the end user signs out of the account.
-    async removeSession(_sessionId: string): Promise<void> {
-        console.log("> removeSession for", _sessionId);
-        const tenantId = this.getTenantNameFromSessionId(_sessionId);
+    async removeSession(tenantId: string): Promise<void> {
+        console.log("> removeSession for", tenantId);
         // Remove PAT or just AccessToken?
         this.tenantService.removeTenantAccessToken(tenantId);
     }
 
 
-    private async askPATClientId(): Promise<string | undefined> {
-        const result = await window.showInputBox({
-            value: '',
-            ignoreFocusOut: true,
-            placeHolder: '806c451e057b442ba67b5d459716e97a',
-            prompt: 'Enter a Personal Access Token (PAT) Client ID.',
-            title: 'Identity Security Cloud',
-            validateInput: text => {
-                const regex = new RegExp('^[a-f0-9]{32}$');
-                if (regex.test(text)) {
-                    return null;
-                }
-                return "Invalid client ID";
-            }
-        });
 
-        return result;
-    }
-
-    private async askPATClientSecret(): Promise<string | undefined> {
-        const result = await window.showInputBox({
-            value: '',
-            password: true,
-            ignoreFocusOut: true,
-            placeHolder: '***',
-            prompt: 'Enter a Personal Access Token (PAT) Secret.',
-            title: 'Identity Security Cloud',
-            validateInput: text => {
-                const regex = new RegExp('^[a-f0-9]{63,64}$');
-                if (regex.test(text)) {
-                    return null;
-                }
-                return "Invalid secret";
-            }
-        });
-        return result;
-    }
-
-    private async askAccessToken(): Promise<string | undefined> {
-        const result = await window.showInputBox({
-            value: '',
-            password: true,
-            ignoreFocusOut: true,
-            placeHolder: '***',
-            prompt: 'Enter an Access Token.',
-            title: 'Identity Security Cloud',
-            validateInput: text => {
-                const regex = new RegExp('^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_+/=-]+)$');
-                if (regex.test(text)) {
-                    return null;
-                }
-                return "Invalid access token";
-            }
-        });
-        return result;
-    }
 }
 

--- a/src/services/TreeManager.ts
+++ b/src/services/TreeManager.ts
@@ -14,9 +14,7 @@ import { isTenantReadonly, validateTenantReadonly } from '../commands/validateTe
 export class TreeManager {
 
     constructor(
-        private readonly dataProvider: ISCDataProvider,
         private readonly tenantService: TenantService,
-        private readonly authProvider: SailPointISCAuthenticationProvider,
         private readonly transformEvaluator: TransformEvaluator,
     ) { }
 
@@ -38,12 +36,7 @@ export class TreeManager {
             return;
         }
         try {
-            const session = await vscode.authentication.getSession(
-                SailPointISCAuthenticationProvider.id,
-                [item.tenantId], { createIfNone: true });
-            if (session !== undefined) {
-                this.authProvider.removeSession(session.id);
-            }
+            SailPointISCAuthenticationProvider.getInstance().removeSession(item.tenantId)
         } catch (err) {
             console.error("Session for ", tenantName, "does not exist:", err);
         }


### PR DESCRIPTION
As per https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference, the authentication provider capability in VSCode now support several accounts.
Each time I tried to access a tenant, it was popping to now which "session" to use.
I got ride of the code for VSCode Authentication Provider implementation to have my own authentication provider.
There won't be any popup anymore.

As a "side" effect, the authentication provider is not available to other extension.
As of now, I don't see that as a problem as it was not meant to be used by other extension anyway.