### PR TITLE
Fixed issue with duplicate review summaries (SAASTRIAGE-7886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ This changelog is following the recommended format by [keepachangelog](https://k
 
 ### Removed
 
+## [1.3.18] - 2025-07-03
+
+### Security
+
+### Added
+
+### Changed
+
+- Updated the SailPoint SDK (sailpoint-api-client) from v1.4.15 to v1.6.2 by [@mostafa-helmy-sp]
+- Updated certification campaign commands to use V2025 APIs by [@mostafa-helmy-sp]
+
+### Fixed
+
+- Issue with duplicate review summaries when reassigning to access owners by [@mostafa-helmy-sp] (SAASTRIAGE-7886)
+
+### Removed
+
 ## [1.3.17] - 2025-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -419,6 +419,12 @@ The extension supports the following settings:
 
 ## Release Notes
 
+### 1.3.18
+
+- Updated the SailPoint SDK (sailpoint-api-client) from v1.4.15 to v1.6.2 by [@mostafa-helmy-sp]
+- Updated certification campaign commands to use V2025 APIs by [@mostafa-helmy-sp]
+- Issue with duplicate review summaries when reassigning to access owners by [@mostafa-helmy-sp] (SAASTRIAGE-7886)
+
 ### 1.3.17
 
 - New command to import account without optimization

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "csv-parse": "^5.4.0",
         "fast-json-patch": "^3.1.1",
         "lodash": "^4.17.21",
-        "sailpoint-api-client": "^1.4.15",
+        "sailpoint-api-client": "^1.6.2",
         "tmp": "^0.2.1",
         "vscode-sailpoint-identitynow": "file:"
       },
@@ -1237,10 +1237,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2120,10 +2121,11 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2682,10 +2684,11 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3240,11 +3243,12 @@
       "dev": true
     },
     "node_modules/sailpoint-api-client": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/sailpoint-api-client/-/sailpoint-api-client-1.4.15.tgz",
-      "integrity": "sha512-eiE6yvzYxZ3gchXXs8zrnLYbJODmVfpLNR2yCOID1GdFvg3JHQA6m57Eu3HdF7v90Cd0V8kgZ7ESln/JcDWG9g==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sailpoint-api-client/-/sailpoint-api-client-1.6.3.tgz",
+      "integrity": "sha512-vitnqDixMUZc7mSbZuRisXoRU8jU9l5xXQt0OyIfG86EuscYvxf/WQEh0nEcDYH+Q6xFdcGl7hhMQbT0pn4ZBg==",
+      "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.7",
+        "axios": "^1.8.3",
         "axios-retry": "^3.4.0",
         "js-yaml": "^4.1.0",
         "proxy-agent": "^6.4.0"

--- a/package.json
+++ b/package.json
@@ -1745,7 +1745,7 @@
     "csv-parse": "^5.4.0",
     "fast-json-patch": "^3.1.1",
     "lodash": "^4.17.21",
-    "sailpoint-api-client": "^1.4.15",
+    "sailpoint-api-client": "^1.6.2",
     "tmp": "^0.2.1",
     "vscode-sailpoint-identitynow": "file:"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sailpoint-identitynow",
   "displayName": "SailPoint Identity Security Cloud",
   "description": "Customize SailPoint Identity Security Cloud",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "publisher": "yannick-beot-sp",
   "icon": "resources/isc.png",
   "bugs": {

--- a/src/campaign-webview/BulkCampaignManagerEscalation.ts
+++ b/src/campaign-webview/BulkCampaignManagerEscalation.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { AdminReviewReassignReassignTo,AdminReviewReassignReassignToTypeV3,CampaignStatusV3,CertificationCampaignsApiMoveRequest, IdentityCertificationDto } from "sailpoint-api-client";
+import { AdminReviewReassignReassignToV2025, CertificationCampaignsV2025ApiMoveRequest, DtoTypeV2025, GetActiveCampaigns200ResponseInnerV2025StatusV2025, IdentityCertificationDtoV2025 } from "sailpoint-api-client";
 import { ISCClient } from "../services/ISCClient";
 
 const CERTIFICATIONS_REASSIGN_LIMIT = 250;
@@ -13,7 +13,7 @@ export class BulkCampaignManagerEscalation {
         const campaign = await this.client.getCampaign(campaignId);
 
         // Ensure the campaign is not completed
-        if (campaign.status === CampaignStatusV3.Completed) {
+        if (campaign.status === GetActiveCampaigns200ResponseInnerV2025StatusV2025.Completed) {
             console.log(`< BulkCampaignManagerEscalation.execute: Campaign ${campaignId} is completed. Exiting script.`);
             vscode.window.showWarningMessage(`Campaign ${campaign.name} is already completed. Cannot reassign certifications.`)
             return;
@@ -29,7 +29,7 @@ export class BulkCampaignManagerEscalation {
         await this.escalateCertifications(campaignId, campaign.name, pendingCertifications)
     }
 
-    async escalateCertifications(campaignId: string, campaignName: string, pendingCertifications:IdentityCertificationDto[]) {
+    async escalateCertifications(campaignId: string, campaignName: string, pendingCertifications: IdentityCertificationDtoV2025[]) {
         let nbRreassignment = 0
         // Build campaign reassignments map (based on the current reviewer's manager)
         const campaignReassignments = new Map<string, string[]>();
@@ -62,17 +62,17 @@ export class BulkCampaignManagerEscalation {
 
 
     private async processReviewerReassignments(campaignId: string, reviewerId: string, allCertificationIds: string[], reassignReason: string) {
-        const newReviewer: AdminReviewReassignReassignTo = {
+        const newReviewer: AdminReviewReassignReassignToV2025 = {
             id: reviewerId,
-            type: AdminReviewReassignReassignToTypeV3.Identity
+            type: DtoTypeV2025.Identity
         }
 
         while (allCertificationIds.length > 0) {
             // Split the reassign references to not exceed the API limit
             const certificationIds = allCertificationIds.splice(0, CERTIFICATIONS_REASSIGN_LIMIT);
-            const certificationMoveRequest: CertificationCampaignsApiMoveRequest = {
+            const certificationMoveRequest: CertificationCampaignsV2025ApiMoveRequest = {
                 id: campaignId,
-                adminReviewReassign: {
+                adminReviewReassignV2025: {
                     certificationIds: certificationIds,
                     reassignTo: newReviewer,
                     reason: reassignReason

--- a/src/campaign-webview/BulkCertificationDecision.ts
+++ b/src/campaign-webview/BulkCertificationDecision.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { CertificationsApiMakeIdentityDecisionRequest, IdentityCertificationDto, AccessReviewItem, ReviewDecision, CertificationDecision } from "sailpoint-api-client";
+import { IdentityCertificationDtoV2025, AccessReviewItemV2025, ReviewDecisionV2025, CertificationDecisionV2025, CertificationsV2025ApiMakeIdentityDecisionRequest } from "sailpoint-api-client";
 import { ISCClient } from "../services/ISCClient";
 
 const DECIDE_CERTIFICATION_ITEM_LIMIT = 250;
@@ -14,7 +14,7 @@ export class BulkCertificationDecision {
     constructor(private readonly client: ISCClient) { }
 
     async processBulkDecision(
-        certifications: IdentityCertificationDto[]
+        certifications: IdentityCertificationDtoV2025[]
     ): Promise<DecisionReport> {
         const report: DecisionReport = {
             success: 0,
@@ -23,9 +23,9 @@ export class BulkCertificationDecision {
         };
 
         // Prompt for the decision
-        const decisionOptions: { label: string; value: CertificationDecision }[] = [
-            { label: 'Approve', value: CertificationDecision.Approve },
-            { label: 'Revoke', value: CertificationDecision.Revoke },
+        const decisionOptions: { label: string; value: CertificationDecisionV2025 }[] = [
+            { label: 'Approve', value: CertificationDecisionV2025.Approve },
+            { label: 'Revoke', value: CertificationDecisionV2025.Revoke },
         ];
         const selectedValue = await vscode.window.showQuickPick(
             decisionOptions.map(option => option.label),
@@ -43,7 +43,7 @@ export class BulkCertificationDecision {
         }
 
         // Map decision label back to the CertificationDecision
-        const certificaionDecision: CertificationDecision | undefined = decisionOptions.find(o => o.label === selectedValue)?.value;
+        const certificaionDecision: CertificationDecisionV2025 | undefined = decisionOptions.find(o => o.label === selectedValue)?.value;
 
         // Prompt for a comment
         const comment = await vscode.window.showInputBox({
@@ -120,17 +120,17 @@ export class BulkCertificationDecision {
 
     private async processBatch(
         certificationId: string,
-        batch: AccessReviewItem[],
-        decision: CertificationDecision,
+        batch: AccessReviewItemV2025[],
+        decision: CertificationDecisionV2025,
         comment: string
     ): Promise<void> {
-        let decisions: ReviewDecision[] = [];
+        let decisions: ReviewDecisionV2025[] = [];
         batch.forEach(accessReviewItem => {
             decisions.push({ id: accessReviewItem.id, bulk: true, decision: decision, comments: comment })
         });
-        const apiDecisionRequest: CertificationsApiMakeIdentityDecisionRequest = {
+        const apiDecisionRequest: CertificationsV2025ApiMakeIdentityDecisionRequest = {
             id: certificationId,
-            reviewDecision: decisions
+            reviewDecisionV2025: decisions
         };
 
         await this.client.decideCertificationItems(apiDecisionRequest);

--- a/src/campaign-webview/reassignOwnersCommand.ts
+++ b/src/campaign-webview/reassignOwnersCommand.ts
@@ -20,7 +20,6 @@ export class ReassignOwnersCommand {
     async execute(node: CampaignTreeItem): Promise<void> {
         console.log("> ReassignOwnersCommand.execute", node);
 
-
         const isReadOnly = isTenantReadonly(this.tenantService, node.tenantId)
 
         if ((isReadOnly && !(await validateTenantReadonly(this.tenantService, node.tenantId, `reassign access item reviews to the access item owners for the campaign ${node.label}?`)))

--- a/src/services/ISCClient.ts
+++ b/src/services/ISCClient.ts
@@ -8,7 +8,7 @@ import { SailPointISCAuthenticationProvider } from "./AuthenticationProvider";
 import { compareByName, convertToText } from "../utils";
 import { DEFAULT_ACCOUNTS_QUERY_PARAMS } from "../models/Account";
 import { DEFAULT_ENTITLEMENTS_QUERY_PARAMS } from "../models/Entitlements";
-import { Configuration, IdentityProfilesApi, IdentityProfile, LifecycleState, LifecycleStatesApi, Paginator, ServiceDeskIntegrationApi, ServiceDeskIntegrationDto, Source, SourcesApi, TransformsApi, WorkflowsBetaApi, WorkflowBeta, WorkflowExecutionBeta, WorkflowLibraryTriggerBeta, ConnectorRuleManagementBetaApi, ConnectorRuleResponseBeta, ConnectorRuleValidationResponseBeta, AccountsApi, AccountsApiListAccountsRequest, Account, EntitlementsBetaApi, EntitlementsBetaApiListEntitlementsRequest, PublicIdentitiesApi, PublicIdentitiesApiGetPublicIdentitiesRequest, PublicIdentity, JsonPatchOperationBeta, SPConfigBetaApi, SpConfigImportResultsBeta, SpConfigJobBeta, ImportOptionsBeta, SpConfigExportResultsBeta, ObjectExportImportOptionsBeta, TransformRead, GovernanceGroupsBetaApi, WorkgroupDtoBeta, AccessProfilesApi, AccessProfilesApiListAccessProfilesRequest, AccessProfile, RolesApi, Role, RolesApiListRolesRequest, Search, SearchApi, IdentityDocument, SearchDocument, AccessProfileDocument, EntitlementDocument, EntitlementBeta, RoleDocument, SourcesBetaApi, StatusResponseBeta, Schema, FormBeta, CustomFormsBetaApi, ExportFormDefinitionsByTenant200ResponseInnerBeta, FormDefinitionResponseBeta, NotificationsBetaApi, TemplateDtoBeta, SegmentsApi, Segment, SearchAttributeConfigurationBetaApi, SearchAttributeConfigBeta, IdentityAttributesBetaApi, IdentityAttributeBeta, PasswordConfigurationApi, PasswordOrgConfig, PasswordManagementBetaApi, ConnectorRuleUpdateRequestBeta, IdentitiesBetaApi, IdentitiesBetaApiListIdentitiesRequest, IdentityBeta, IdentitySyncJobBeta, TaskResultResponseBeta, LoadEntitlementTaskBeta, TaskManagementBetaApi, TaskStatusBeta, EntitlementSourceResetBaseReferenceDtoBeta, TaskResultDtoBeta, ProvisioningPolicyDto, ImportFormDefinitionsRequestInnerBeta, ManagedClustersBetaApi, StandardLevelBeta, CertificationCampaignsApi, CertificationsApi, CertificationCampaignsApiMoveRequest, CertificationSummariesApi, IdentityCertDecisionSummary, AccessReviewItem, CertificationCampaignFiltersApiFp, IdentityCertificationDto, GetActiveCampaigns200ResponseInner, CertificationsApiSubmitReassignCertsAsyncRequest, WorkflowsApi, ExportPayloadBetaIncludeTypesBeta, SODPoliciesV2024Api, SodPolicyV2024, CertificationTask, AppsBetaApi, SourceAppBeta, ConfigurationHubV2024Api, BackupResponseV2024, CertificationsApiMakeIdentityDecisionRequest, CertificationsApiReassignIdentityCertificationsRequest } from 'sailpoint-api-client';
+import { Configuration, IdentityProfilesApi, IdentityProfile, LifecycleState, LifecycleStatesApi, Paginator, ServiceDeskIntegrationApi, ServiceDeskIntegrationDto, Source, SourcesApi, TransformsApi, WorkflowsBetaApi, WorkflowBeta, WorkflowExecutionBeta, WorkflowLibraryTriggerBeta, ConnectorRuleManagementBetaApi, ConnectorRuleResponseBeta, ConnectorRuleValidationResponseBeta, AccountsApi, AccountsApiListAccountsRequest, Account, EntitlementsBetaApi, EntitlementsBetaApiListEntitlementsRequest, PublicIdentitiesApi, PublicIdentitiesApiGetPublicIdentitiesRequest, PublicIdentity, JsonPatchOperationBeta, SPConfigBetaApi, SpConfigImportResultsBeta, SpConfigJobBeta, ImportOptionsBeta, SpConfigExportResultsBeta, ObjectExportImportOptionsBeta, TransformRead, GovernanceGroupsBetaApi, WorkgroupDtoBeta, AccessProfilesApi, AccessProfilesApiListAccessProfilesRequest, AccessProfile, RolesApi, Role, RolesApiListRolesRequest, Search, SearchApi, IdentityDocument, SearchDocument, AccessProfileDocument, EntitlementDocument, EntitlementBeta, RoleDocument, SourcesBetaApi, StatusResponseBeta, Schema, FormBeta, CustomFormsBetaApi, ExportFormDefinitionsByTenant200ResponseInnerBeta, FormDefinitionResponseBeta, NotificationsBetaApi, TemplateDtoBeta, SegmentsApi, Segment, SearchAttributeConfigurationBetaApi, SearchAttributeConfigBeta, IdentityAttributesBetaApi, IdentityAttributeBeta, PasswordConfigurationApi, PasswordOrgConfig, PasswordManagementBetaApi, ConnectorRuleUpdateRequestBeta, IdentitiesBetaApi, IdentitiesBetaApiListIdentitiesRequest, IdentityBeta, IdentitySyncJobBeta, TaskResultResponseBeta, LoadEntitlementTaskBeta, TaskManagementBetaApi, TaskStatusBeta, EntitlementSourceResetBaseReferenceDtoBeta, TaskResultDtoBeta, ProvisioningPolicyDto, ImportFormDefinitionsRequestInnerBeta, ManagedClustersBetaApi, StandardLevelBeta, CertificationCampaignsV2025Api, CertificationsV2025Api, CertificationCampaignsV2025ApiMoveRequest, CertificationSummariesV2025Api, IdentityCertDecisionSummaryV2025, AccessReviewItemV2025, CertificationsV2025ApiReassignIdentityCertificationsRequest, CertificationsV2025ApiMakeIdentityDecisionRequest, IdentityCertificationDtoV2025, GetActiveCampaigns200ResponseInnerV2025, CertificationsV2025ApiSubmitReassignCertsAsyncRequest, WorkflowsApi, ExportPayloadBetaIncludeTypesBeta, SODPoliciesV2024Api, SodPolicyV2024, CertificationTask, AppsBetaApi, SourceAppBeta, ConfigurationHubV2024Api, BackupResponseV2024 } from 'sailpoint-api-client';
 import { DEFAULT_PUBLIC_IDENTITIES_QUERY_PARAMS } from '../models/PublicIdentity';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { ImportEntitlementsResult } from '../models/JobStatus';
@@ -1702,9 +1702,9 @@ export class ISCClient {
 		return response;
 	}
 
-	public async getCampaign(campaignId: string): Promise<GetActiveCampaigns200ResponseInner> {
+	public async getCampaign(campaignId: string): Promise<GetActiveCampaigns200ResponseInnerV2025> {
 		const apiConfig = await this.getApiConfiguration();
-		const api = new CertificationCampaignsApi(apiConfig, undefined, this.getAxiosWithInterceptors());
+		const api = new CertificationCampaignsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors());
 
 		const val = await api.getCampaign({ id: campaignId });
 
@@ -1715,7 +1715,7 @@ export class ISCClient {
 		return val.data;
 	}
 
-	public async getCampaignCertifications(campaignId: string, completed?: boolean): Promise<IdentityCertificationDto[]> {
+	public async getCampaignCertifications(campaignId: string, completed?: boolean): Promise<IdentityCertificationDtoV2025[]> {
 		let filters = `campaign.id eq "${campaignId}"`
 		if (completed !== undefined) {
 			filters += ` and completed eq ${completed}`
@@ -1723,9 +1723,9 @@ export class ISCClient {
 		return this.getCampaignCertificationsByFilter(filters);
 	}
 
-	public async getCampaignCertificationsByFilter(filters: string): Promise<IdentityCertificationDto[]> {
+	public async getCampaignCertificationsByFilter(filters: string): Promise<IdentityCertificationDtoV2025[]> {
 		const apiConfig = await this.getApiConfiguration();
-		const api = new CertificationsApi(apiConfig, undefined, this.getAxiosWithInterceptors());
+		const api = new CertificationsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors());
 
 		const val = await Paginator.paginate(
 			api,
@@ -1743,9 +1743,9 @@ export class ISCClient {
 		return val.data;
 	}
 
-	public async getCertificationReviewItems(certificationId: string, completed?: boolean): Promise<AccessReviewItem[]> {
+	public async getCertificationReviewItems(certificationId: string, completed?: boolean): Promise<AccessReviewItemV2025[]> {
 		const apiConfig = await this.getApiConfiguration();
-		const api = new CertificationsApi(apiConfig, undefined, this.getAxiosWithInterceptors());
+		const api = new CertificationsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors());
 
 		let filters
 		if (completed !== undefined) {
@@ -1768,8 +1768,8 @@ export class ISCClient {
 		return val.data;
 	}
 
-	public async getCampaignReviewItems(campaignId: string): Promise<AccessReviewItem[]> {
-		let allAccessReviewItems: AccessReviewItem[] = []
+	public async getCampaignReviewItems(campaignId: string): Promise<AccessReviewItemV2025[]> {
+		let allAccessReviewItems: AccessReviewItemV2025[] = []
 		const certifications = await this.getCampaignCertifications(campaignId, false)
 		for (const certification of certifications) {
 			const accessReviewItems = await this.getCertificationReviewItems(certification.id)
@@ -1783,9 +1783,9 @@ export class ISCClient {
 		offset: number,
 		sorters?: string,
 		limit?: number
-	}): Promise<PaginatedData<IdentityCertificationDto>> {
+	}): Promise<PaginatedData<IdentityCertificationDtoV2025>> {
 		const apiConfig = await this.getApiConfiguration();
-		const api = new CertificationsApi(apiConfig, undefined, this.getAxiosWithInterceptors());
+		const api = new CertificationsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors());
 		let filters = `campaign.id eq "${campaignId}"`
 		const resp = await api.listIdentityCertifications({
 			filters,
@@ -1804,36 +1804,36 @@ export class ISCClient {
 		}
 	}
 
-	public async getSummaryCertificationDecisions(certificationId: string): Promise<IdentityCertDecisionSummary> {
+	public async getSummaryCertificationDecisions(certificationId: string): Promise<IdentityCertDecisionSummaryV2025> {
 		const apiConfig = await this.getApiConfiguration();
-		const api = new CertificationSummariesApi(apiConfig, undefined, this.getAxiosWithInterceptors());
+		const api = new CertificationSummariesV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors());
 		const resp = await api.getIdentityDecisionSummary({ id: certificationId })
 		return resp.data
 	}
 
-	public async reassignCampaignCertifications(certificationMoveRequest: CertificationCampaignsApiMoveRequest): Promise<void> {
+	public async reassignCampaignCertifications(certificationMoveRequest: CertificationCampaignsV2025ApiMoveRequest): Promise<void> {
 		const apiConfig = await this.getApiConfiguration();
-		const campaignApi = new CertificationCampaignsApi(apiConfig, undefined, this.getAxiosWithInterceptors())
+		const campaignApi = new CertificationCampaignsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors())
 		await campaignApi.move(certificationMoveRequest);
 	}
 
-	public async reassignCertificationReviewItemsSync(certificationReassignRequestSync: CertificationsApiReassignIdentityCertificationsRequest): Promise<CertificationTask> {
+	public async reassignCertificationReviewItemsSync(certificationReassignRequestSync: CertificationsV2025ApiReassignIdentityCertificationsRequest): Promise<CertificationTask> {
 		const apiConfig = await this.getApiConfiguration();
-		const certificationsApi = new CertificationsApi(apiConfig, undefined, this.getAxiosWithInterceptors())
+		const certificationsApi = new CertificationsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors())
 		const resp = await certificationsApi.reassignIdentityCertifications(certificationReassignRequestSync)
 		return resp.data
 	}
 
-	public async reassignCertificationReviewItemsAsync(certificationReassignRequestAsync: CertificationsApiSubmitReassignCertsAsyncRequest): Promise<CertificationTask> {
+	public async reassignCertificationReviewItemsAsync(certificationReassignRequestAsync: CertificationsV2025ApiSubmitReassignCertsAsyncRequest): Promise<CertificationTask> {
 		const apiConfig = await this.getApiConfiguration();
-		const certificationsApi = new CertificationsApi(apiConfig, undefined, this.getAxiosWithInterceptors())
+		const certificationsApi = new CertificationsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors())
 		const resp = await certificationsApi.submitReassignCertsAsync(certificationReassignRequestAsync)
 		return resp.data
 	}
 
-	public async decideCertificationItems(certificationsApiMakeIdentityDecisionRequest: CertificationsApiMakeIdentityDecisionRequest): Promise<{ IdentityCertificationDto: IdentityCertificationDto }> {
+	public async decideCertificationItems(certificationsApiMakeIdentityDecisionRequest: CertificationsV2025ApiMakeIdentityDecisionRequest): Promise<{ IdentityCertificationDto: IdentityCertificationDtoV2025 }> {
 		const apiConfig = await this.getApiConfiguration();
-		const certificationsApi = new CertificationsApi(apiConfig, undefined, this.getAxiosWithInterceptors())
+		const certificationsApi = new CertificationsV2025Api(apiConfig, undefined, this.getAxiosWithInterceptors())
 		const resp = await certificationsApi.makeIdentityDecision(certificationsApiMakeIdentityDecisionRequest)
 		return {
 			IdentityCertificationDto: resp.data
@@ -2032,9 +2032,3 @@ export class ISCClient {
 	//#endregion Identity Management
 	////////////////////////
 }
-
-export { CertificationsApi, AccessReviewItem, CertificationCampaignFiltersApiFp, Paginator };
-
-
-
-


### PR DESCRIPTION
Reassignment requests are now grouped by reviewer & by identity or access item to avoid duplicate review summaries. This is a limitation by design in the reassign API that was not publicly documented.

All certification APIs updated to V2025.