### PR TITLE
add support for additional owners and governance groups in access pro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ The following table provides the expected column for the CSV to import Access Pr
 | ------------------------ | ---- | --------------------------------------------------------------------------------------------------------------------------- | ------------------ |
 | `name`                   | Yes  | Name of the access profile                                                                                                  |                    |
 | `owner`                  | Yes  | Owner of the access profile                                                                                                 |                    |
+| `additionalOwners`       | No   | Additional owners (identity names or IDs), separated by ;. Maximum 10 identities. Mutually exclusive with `additionalOwnerGovernanceGroup`. | `[]`               |
+| `additionalOwnerGovernanceGroup` | No | Additional owners as a single governance group name. Mutually exclusive with `additionalOwners`.                         | `null`             |
 | `source`                 | Yes  | Source associated with the access profile                                                                                   |                    |
 | `description`            | No   | Description of the access profile                                                                                           | `null`             |
 | `enabled`                | No   | Is the access profile enabled?                                                                                              | `false`            |
@@ -196,6 +198,8 @@ The following table provides the expected column for the CSV to import Roles:
 | ------------------------------ | ---- | ---------------------------------------------------------------------------------------------- | ------------------ |
 | `name`                         | Yes  | Name of the role                                                                               |                    |
 | `owner`                        | Yes  | Owner of the role                                                                              |                    |
+| `additionalOwners`             | No   | Additional owners (identity names or IDs), separated by ;. Maximum 10 identities. Mutually exclusive with `additionalOwnerGovernanceGroup`. | `[]`               |
+| `additionalOwnerGovernanceGroup` | No | Additional owners as a single governance group name. Mutually exclusive with `additionalOwners`.                         | `null`             |
 | `description`                  | No   | Description of the role                                                                        | `null`             |
 | `enabled`                      | No   | Is the role enabled?                                                                           | `false`            |
 | `requestable`                  | No   | Is the role requestable?                                                                       | `false`            |
@@ -336,6 +340,23 @@ The metadata column will be exported as or will be imported as:
 > For custom metadata attribute and values, it's just the Camel Case of the display name. e.g. Domain->`domain`, Back Office->`backOffice`
 >
 > Default metadata starts with isc. For instance, "Access Type"'s technical name is `iscAccessType`
+
+### Entitlement Details
+
+The following table provides the expected columns for the CSV to import entitlement details (metadata updates):
+
+| Header                          | M[*] | Description                                                                 | Default Value |
+| ------------------------------- | ---- | --------------------------------------------------------------------------- | ------------- |
+| `attributeName`                 | Yes  | Entitlement attribute name                                                  |               |
+| `attributeValue`                | Yes  | Entitlement attribute value                                                 |               |
+| `schema`                        | Yes  | Entitlement schema/object type                                              |               |
+| `displayName`                   | No   | Entitlement display name                                                    |               |
+| `description`                   | No   | Entitlement description                                                     |               |
+| `requestable`                   | No   | Whether entitlement is requestable                                          |               |
+| `owner`                         | No   | Primary owner (identity alias or ID)                                        |               |
+| `additionalOwners`              | No   | Additional owners (identity names or IDs), separated by ;. Maximum 10 identities. Mutually exclusive with `additionalOwnerGovernanceGroup`. | `[]`          |
+| `additionalOwnerGovernanceGroup`| No   | Additional owners as a single governance group name. Mutually exclusive with `additionalOwners`. | `null`        |
+| `privileged`                    | No   | Whether entitlement is privileged                                           |               |
 
 ### Certification Campaign Custom Reviewers
 

--- a/snippets/access-profile.json
+++ b/snippets/access-profile.json
@@ -7,6 +7,13 @@
         "id": "<<<OWNER_ID>>>",
         "name": "<<<OWNER_NAME>>>"
     },
+    "additionalOwners": [
+        {
+            "type": "IDENTITY",
+            "id": "<<<ADDITIONAL_OWNER_ID>>>",
+            "name": "<<<ADDITIONAL_OWNER_NAME>>>"
+        }
+    ],
     "source": {},
     "entitlements": [],
     "requestable": true,

--- a/snippets/role.json
+++ b/snippets/role.json
@@ -7,6 +7,13 @@
         "id": "<<OWNER_ID>>",
         "name": "<<OWNER_NAME>>"
     },
+    "additionalOwners": [
+        {
+            "type": "IDENTITY",
+            "id": "<<ADDITIONAL_OWNER_ID>>",
+            "name": "<<ADDITIONAL_OWNER_NAME>>"
+        }
+    ],
     "entitlements": [],
     "accessProfiles": [],
     "membership": null,

--- a/src/commands/access-profile/AccessProfileImporter.ts
+++ b/src/commands/access-profile/AccessProfileImporter.ts
@@ -25,12 +25,71 @@ interface AccessProfileCSVRecord {
     requestable: boolean
     source: string
     owner: string
+    additionalOwners?: string
+    additionalOwnerGovernanceGroup?: string
     entitlements: string
     commentsRequired: boolean
     denialCommentsRequired: boolean
     revokeApprovalSchemes: string
     approvalSchemes: string
     metadata: string
+}
+
+const OWNER_ID_REGEX = /^[a-f0-9]{32}$/;
+
+async function resolveAdditionalOwners(
+    additionalOwnersRaw: string | undefined,
+    additionalOwnerGovernanceGroupRaw: string | undefined,
+    identityCacheService: IdentityNameToIdCacheService,
+    governanceGroupCache: GovernanceGroupNameToIdCacheService
+): Promise<Array<{ type: "IDENTITY" | "GOVERNANCE_GROUP"; id: string; name?: string }> | undefined> {
+    if (additionalOwnersRaw === undefined && additionalOwnerGovernanceGroupRaw === undefined) {
+        return undefined;
+    }
+
+    const ownerNames = (additionalOwnersRaw ?? "")
+        .split(CSV_MULTIVALUE_SEPARATOR)
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+
+    const governanceGroupName = additionalOwnerGovernanceGroupRaw?.trim() ?? "";
+
+    if (governanceGroupName && ownerNames.length > 0) {
+        throw new Error("Both additionalOwners and additionalOwnerGovernanceGroup are set. Only one is allowed.");
+    }
+
+    if (ownerNames.length > 10) {
+        throw new Error("Too many additional owners. Maximum is 10 identities.");
+    }
+
+    if (governanceGroupName) {
+        const groupId = await governanceGroupCache.get(governanceGroupName);
+        return [{
+            type: "GOVERNANCE_GROUP",
+            id: groupId,
+            name: governanceGroupName
+        }];
+    }
+
+    if (ownerNames.length === 0) {
+        return [];
+    }
+
+    return Promise.all(ownerNames.map(async (ownerNameOrId) => {
+        if (OWNER_ID_REGEX.test(ownerNameOrId)) {
+            return {
+                type: "IDENTITY",
+                id: ownerNameOrId
+            };
+        }
+
+        const ownerId = await identityCacheService.get(ownerNameOrId);
+        return {
+            type: "IDENTITY",
+            id: ownerId,
+            name: ownerNameOrId
+        };
+    }));
 }
 
 export class AccessProfileImporter {
@@ -152,6 +211,22 @@ export class AccessProfileImporter {
                     return;
                 }
 
+                let additionalOwners: Array<{ type: "IDENTITY" | "GOVERNANCE_GROUP"; id: string; name?: string }> | undefined;
+                try {
+                    additionalOwners = await resolveAdditionalOwners(
+                        data.additionalOwners,
+                        data.additionalOwnerGovernanceGroup,
+                        identityCacheService,
+                        governanceGroupCache
+                    );
+                } catch (error: any) {
+                    result.error++;
+                    const message = `Invalid additional owners: ${error.message ?? error}`;
+                    await this.writeLog(processedLines, apName, CSVLogWriterLogType.ERROR, message);
+                    vscode.window.showErrorMessage(message);
+                    return;
+                }
+
                 if (token.isCancellationRequested) {
                     throw new UserCancelledError();
                 }
@@ -240,6 +315,10 @@ export class AccessProfileImporter {
                     entitlements
                 }
 
+                if (additionalOwners !== undefined) {
+                    (accessProfilePayload as any).additionalOwners = additionalOwners;
+                }
+
                 if (token.isCancellationRequested) {
                     throw new UserCancelledError();
                 }
@@ -292,6 +371,10 @@ export class AccessProfileImporter {
                                         "name": data.owner
                                     }
                                 },
+                                ...(additionalOwners !== undefined ? [{
+                                    "property": "additionalOwners",
+                                    "value": additionalOwners
+                                }] : []),
                                 {
                                     "property": "accessRequestConfig",
                                     "value": {

--- a/src/commands/access-profile/ExportAccessProfiles.ts
+++ b/src/commands/access-profile/ExportAccessProfiles.ts
@@ -12,6 +12,7 @@ import { IdentityIdToNameCacheService } from '../../services/cache/IdentityIdToN
 import { metadataToString } from '../../utils/metadataUtils';
 import { EntitlementIdToSourceNameCacheService } from '../../services/cache/EntitlementIdToSourceNameCacheService';
 import { entitlementToStringConverter } from '../../utils/entitlementToStringConverter';
+import { CSV_MULTIVALUE_SEPARATOR } from '../../constants';
 
 export class AccessProfileExporterCommand {
     /**
@@ -73,6 +74,8 @@ interface AccessProfileDto {
      * @memberof Role
      */
     'owner': string | null;
+    'additionalOwners'?: string | null;
+    'additionalOwnerGovernanceGroup'?: string | null;
     /**
      *
      * @type {AccessProfileSourceRef}
@@ -108,6 +111,41 @@ interface AccessProfileDto {
      */
     metadata?: string;
 }
+
+type AdditionalOwnerRef = { type?: string; id?: string; name?: string };
+
+async function formatAdditionalOwners(
+    additionalOwners: AdditionalOwnerRef[] | undefined,
+    identityCacheIdToName: IdentityIdToNameCacheService,
+    governanceGroupCacheIdToName: GovernanceGroupIdToNameCacheService
+): Promise<{ additionalOwners: string | null; additionalOwnerGovernanceGroup: string | null }> {
+    if (!additionalOwners || additionalOwners.length === 0) {
+        return { additionalOwners: null, additionalOwnerGovernanceGroup: null };
+    }
+
+    const governanceGroupOwner = additionalOwners.find((owner) => owner.type === "GOVERNANCE_GROUP");
+    if (governanceGroupOwner?.id) {
+        const governanceGroupName = governanceGroupOwner.name
+            ?? await governanceGroupCacheIdToName.get(governanceGroupOwner.id);
+        return { additionalOwners: null, additionalOwnerGovernanceGroup: governanceGroupName };
+    }
+
+    const identityNames = await Promise.all(additionalOwners.map(async (owner) => {
+        if (owner.name) {
+            return owner.name;
+        }
+        if (owner.id) {
+            return identityCacheIdToName.get(owner.id);
+        }
+        return null;
+    }));
+
+    const filteredNames = identityNames.filter((name): name is string => !!name);
+    return {
+        additionalOwners: filteredNames.length ? filteredNames.join(CSV_MULTIVALUE_SEPARATOR) : null,
+        additionalOwnerGovernanceGroup: null
+    };
+}
 class AccessProfileExporter extends BaseCSVExporter<AccessProfile> {
     constructor(
         tenantId: string,
@@ -132,6 +170,8 @@ class AccessProfileExporter extends BaseCSVExporter<AccessProfile> {
             "requestable",
             "source",
             "owner",
+            "additionalOwners",
+            "additionalOwnerGovernanceGroup",
             "commentsRequired",
             "denialCommentsRequired",
             "approvalSchemes",
@@ -146,6 +186,8 @@ class AccessProfileExporter extends BaseCSVExporter<AccessProfile> {
             "requestable",
             "source.name",
             "owner",
+            "additionalOwners",
+            "additionalOwnerGovernanceGroup",
             "accessRequestConfig.commentsRequired",
             "accessRequestConfig.denialCommentsRequired",
             "approvalSchemes",
@@ -168,6 +210,11 @@ class AccessProfileExporter extends BaseCSVExporter<AccessProfile> {
         await this.writeData(headers, paths, unwindablePaths, iterator, task, token,
             async (item: AccessProfile): Promise<AccessProfileDto> => {
                 const owner = item.owner ? (await identityCacheIdToName.get(item.owner.id!)) : null
+                const additionalOwnersInfo = await formatAdditionalOwners(
+                    (item as any).additionalOwners,
+                    identityCacheIdToName,
+                    governanceGroupCache
+                );
 
                 let entitlements: string | undefined = undefined;
                 try {
@@ -187,6 +234,8 @@ class AccessProfileExporter extends BaseCSVExporter<AccessProfile> {
                         name: item.source.name
                     },
                     owner: owner,
+                    additionalOwners: additionalOwnersInfo.additionalOwners,
+                    additionalOwnerGovernanceGroup: additionalOwnersInfo.additionalOwnerGovernanceGroup,
                     entitlements,
                     accessRequestConfig: {
                         commentsRequired: item.accessRequestConfig?.commentsRequired ?? false,

--- a/src/commands/role/ExportRoles.ts
+++ b/src/commands/role/ExportRoles.ts
@@ -76,6 +76,8 @@ export interface RoleDto {
      * @memberof Role
      */
     'owner': string | null;
+    'additionalOwners'?: string | null;
+    'additionalOwnerGovernanceGroup'?: string | null;
     /**
      *
      * @type {Array<AccessProfileRef>}
@@ -134,6 +136,41 @@ export interface RoleDto {
 
 }
 
+type AdditionalOwnerRef = { type?: string; id?: string; name?: string };
+
+async function formatAdditionalOwners(
+    additionalOwners: AdditionalOwnerRef[] | undefined,
+    identityCacheIdToName: IdentityIdToNameCacheService,
+    governanceGroupCacheIdToName: GovernanceGroupIdToNameCacheService
+): Promise<{ additionalOwners: string | null; additionalOwnerGovernanceGroup: string | null }> {
+    if (!additionalOwners || additionalOwners.length === 0) {
+        return { additionalOwners: null, additionalOwnerGovernanceGroup: null };
+    }
+
+    const governanceGroupOwner = additionalOwners.find((owner) => owner.type === "GOVERNANCE_GROUP");
+    if (governanceGroupOwner?.id) {
+        const governanceGroupName = governanceGroupOwner.name
+            ?? await governanceGroupCacheIdToName.get(governanceGroupOwner.id);
+        return { additionalOwners: null, additionalOwnerGovernanceGroup: governanceGroupName };
+    }
+
+    const identityNames = await Promise.all(additionalOwners.map(async (owner) => {
+        if (owner.name) {
+            return owner.name;
+        }
+        if (owner.id) {
+            return identityCacheIdToName.get(owner.id);
+        }
+        return null;
+    }));
+
+    const filteredNames = identityNames.filter((name): name is string => !!name);
+    return {
+        additionalOwners: filteredNames.length ? filteredNames.join(CSV_MULTIVALUE_SEPARATOR) : null,
+        additionalOwnerGovernanceGroup: null
+    };
+}
+
 class RoleExporter extends BaseCSVExporter<Role> {
     constructor(
         tenantId: string,
@@ -157,6 +194,8 @@ class RoleExporter extends BaseCSVExporter<Role> {
             "enabled",
             "requestable",
             "owner",
+            "additionalOwners",
+            "additionalOwnerGovernanceGroup",
             "commentsRequired",
             "denialCommentsRequired",
             "approvalSchemes",
@@ -176,6 +215,8 @@ class RoleExporter extends BaseCSVExporter<Role> {
             "enabled",
             "requestable",
             "owner",
+            "additionalOwners",
+            "additionalOwnerGovernanceGroup",
             "accessRequestConfig.commentsRequired",
             "accessRequestConfig.denialCommentsRequired",
             "approvalSchemes",
@@ -222,6 +263,12 @@ class RoleExporter extends BaseCSVExporter<Role> {
                     console.warn(`Error converting owner identity "${item.owner.id}" for role "${item.name}:"`, error);
                 }
 
+                const additionalOwnersInfo = await formatAdditionalOwners(
+                    (item as any).additionalOwners,
+                    identityCacheIdToName,
+                    governanceGroupCache
+                );
+
                 let entitlements: string | undefined = undefined;
                 try {
                     entitlements = (item.entitlements ? (await entitlementToStringConverter(item.entitlements, entitlementIdToSourceNameCacheService)) : null);
@@ -236,6 +283,8 @@ class RoleExporter extends BaseCSVExporter<Role> {
                     enabled: item.enabled,
                     requestable: item.requestable,
                     owner: owner,
+                    additionalOwners: additionalOwnersInfo.additionalOwners,
+                    additionalOwnerGovernanceGroup: additionalOwnersInfo.additionalOwnerGovernanceGroup,
                     accessProfiles: item.accessProfiles?.map(x => x.name).join(CSV_MULTIVALUE_SEPARATOR),
                     entitlements,
                     accessRequestConfig: {

--- a/src/commands/role/RoleImporter.ts
+++ b/src/commands/role/RoleImporter.ts
@@ -29,6 +29,8 @@ interface RoleCSVRecord {
     enabled: boolean
     requestable: boolean
     owner: string
+    additionalOwners?: string
+    additionalOwnerGovernanceGroup?: string
     commentsRequired: boolean
     denialCommentsRequired: boolean
     approvalSchemes: string
@@ -41,6 +43,63 @@ interface RoleCSVRecord {
     dimensional?: boolean
     dimensionAttributes?: string
     metadata: string
+}
+
+const OWNER_ID_REGEX = /^[a-f0-9]{32}$/;
+
+async function resolveAdditionalOwners(
+    additionalOwnersRaw: string | undefined,
+    additionalOwnerGovernanceGroupRaw: string | undefined,
+    identityCacheService: IdentityNameToIdCacheService,
+    governanceGroupCache: GovernanceGroupNameToIdCacheService
+): Promise<Array<{ type: "IDENTITY" | "GOVERNANCE_GROUP"; id: string; name?: string }> | undefined> {
+    if (additionalOwnersRaw === undefined && additionalOwnerGovernanceGroupRaw === undefined) {
+        return undefined;
+    }
+
+    const ownerNames = (additionalOwnersRaw ?? "")
+        .split(CSV_MULTIVALUE_SEPARATOR)
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+
+    const governanceGroupName = additionalOwnerGovernanceGroupRaw?.trim() ?? "";
+
+    if (governanceGroupName && ownerNames.length > 0) {
+        throw new Error("Both additionalOwners and additionalOwnerGovernanceGroup are set. Only one is allowed.");
+    }
+
+    if (ownerNames.length > 10) {
+        throw new Error("Too many additional owners. Maximum is 10 identities.");
+    }
+
+    if (governanceGroupName) {
+        const groupId = await governanceGroupCache.get(governanceGroupName);
+        return [{
+            type: "GOVERNANCE_GROUP",
+            id: groupId,
+            name: governanceGroupName
+        }];
+    }
+
+    if (ownerNames.length === 0) {
+        return [];
+    }
+
+    return Promise.all(ownerNames.map(async (ownerNameOrId) => {
+        if (OWNER_ID_REGEX.test(ownerNameOrId)) {
+            return {
+                type: "IDENTITY",
+                id: ownerNameOrId
+            };
+        }
+
+        const ownerId = await identityCacheService.get(ownerNameOrId);
+        return {
+            type: "IDENTITY",
+            id: ownerId,
+            name: ownerNameOrId
+        };
+    }));
 }
 
 export class RoleImporter {
@@ -137,6 +196,22 @@ export class RoleImporter {
                     const srcMessage = `Unable to find owner with name '${data.owner}' in ISC`;
                     await this.writeLog(processedLines, roleName, CSVLogWriterLogType.ERROR, srcMessage);
                     vscode.window.showErrorMessage(srcMessage);
+                    return;
+                }
+
+                let additionalOwners: Array<{ type: "IDENTITY" | "GOVERNANCE_GROUP"; id: string; name?: string }> | undefined;
+                try {
+                    additionalOwners = await resolveAdditionalOwners(
+                        data.additionalOwners,
+                        data.additionalOwnerGovernanceGroup,
+                        identityCacheService,
+                        governanceGroupCache
+                    );
+                } catch (error: any) {
+                    result.error++;
+                    const message = `Invalid additional owners: ${error.message ?? error}`;
+                    await this.writeLog(processedLines, roleName, CSVLogWriterLogType.ERROR, message);
+                    vscode.window.showErrorMessage(message);
                     return;
                 }
 
@@ -283,6 +358,10 @@ export class RoleImporter {
                     dimensional: truethy(data.dimensional),
                 };
 
+                if (additionalOwners !== undefined) {
+                    (rolePayload as any).additionalOwners = additionalOwners;
+                }
+
 
                 if (token.isCancellationRequested) {
                     throw new UserCancelledError();
@@ -336,6 +415,10 @@ export class RoleImporter {
                                         "name": data.owner
                                     }
                                 },
+                                ...(additionalOwners !== undefined ? [{
+                                    "property": "additionalOwners",
+                                    "value": additionalOwners
+                                }] : []),
                                 {
                                     "property": "accessRequestConfig",
                                     "value": {

--- a/src/commands/source/exportEntitlementDetails.ts
+++ b/src/commands/source/exportEntitlementDetails.ts
@@ -5,6 +5,9 @@ import { askFile } from '../../utils/vsCodeHelpers';
 import { BaseCSVExporter } from '../BaseExporter';
 import EntitlementPaginator from './EntitlementPaginator';
 import { Entitlement } from 'sailpoint-api-client';
+import { CSV_MULTIVALUE_SEPARATOR } from '../../constants';
+import { IdentityIdToNameCacheService } from '../../services/cache/IdentityIdToNameCacheService';
+import { GovernanceGroupIdToNameCacheService } from '../../services/cache/GovernanceGroupIdToNameCacheService';
 
 
 export class EntitlementExporterCommand {
@@ -68,15 +71,77 @@ class EntitlementExporter extends BaseCSVExporter<Entitlement> {
     protected async exportFile(task: any, token: vscode.CancellationToken): Promise<void> {
         console.log("> BaseEntitlementExporter.exportFile");
         const headers = [
-            "attributeName", "attributeValue", "displayName", "description", "schema", "privileged", "requestable", "owner"
+            "attributeName",
+            "attributeValue",
+            "displayName",
+            "description",
+            "schema",
+            "privileged",
+            "requestable",
+            "owner",
+            "additionalOwners",
+            "additionalOwnerGovernanceGroup"
         ];
         const paths = [
-            "attribute", "value", "name", "description", "sourceSchemaObjectType", "privileged", "requestable", "owner.name"
+            "attribute",
+            "value",
+            "name",
+            "description",
+            "sourceSchemaObjectType",
+            "privileged",
+            "requestable",
+            "owner.name",
+            "additionalOwners",
+            "additionalOwnerGovernanceGroup"
         ];
         const unwindablePaths: string[] = [];
 
         const iterator = new EntitlementPaginator(this.client, this.sourceId);
-        await this.writeData(headers, paths, unwindablePaths, iterator, task, token);
+        const identityCacheIdToName = new IdentityIdToNameCacheService(this.client);
+        const governanceGroupCacheIdToName = new GovernanceGroupIdToNameCacheService(this.client);
+
+        await this.writeData(headers, paths, unwindablePaths, iterator, task, token,
+            async (item: Entitlement): Promise<any> => {
+                const additionalOwners = (item as any).additionalOwners as Array<{ type?: string; id?: string; name?: string }> | undefined;
+
+                let additionalOwnersValue: string | null = null;
+                let additionalOwnerGovernanceGroup: string | null = null;
+
+                if (additionalOwners && additionalOwners.length > 0) {
+                    const governanceGroupOwner = additionalOwners.find((owner) => owner.type === "GOVERNANCE_GROUP");
+                    if (governanceGroupOwner?.id) {
+                        additionalOwnerGovernanceGroup = governanceGroupOwner.name
+                            ?? await governanceGroupCacheIdToName.get(governanceGroupOwner.id);
+                    } else {
+                        const identityNames = await Promise.all(additionalOwners.map(async (owner) => {
+                            if (owner.name) {
+                                return owner.name;
+                            }
+                            if (owner.id) {
+                                return identityCacheIdToName.get(owner.id);
+                            }
+                            return null;
+                        }));
+                        additionalOwnersValue = identityNames.filter((name): name is string => !!name)
+                            .join(CSV_MULTIVALUE_SEPARATOR);
+                    }
+                }
+
+                return {
+                    attribute: (item as any).attribute,
+                    value: (item as any).value,
+                    name: (item as any).name,
+                    description: (item as any).description,
+                    sourceSchemaObjectType: (item as any).sourceSchemaObjectType,
+                    privileged: (item as any).privileged,
+                    requestable: (item as any).requestable,
+                    owner: {
+                        name: (item as any).owner?.name ?? null
+                    },
+                    additionalOwners: additionalOwnersValue,
+                    additionalOwnerGovernanceGroup: additionalOwnerGovernanceGroup
+                };
+            });
     }
 
 }

--- a/src/commands/source/importEntitlementDetails.ts
+++ b/src/commands/source/importEntitlementDetails.ts
@@ -7,11 +7,15 @@ import { chooseFile } from '../../utils/vsCodeHelpers';
 import { JsonPatchOperationBeta } from 'sailpoint-api-client';
 import { TenantService } from '../../services/TenantService';
 import { validateTenantReadonly } from '../validateTenantReadonly';
+import { IdentityNameToIdCacheService } from '../../services/cache/IdentityNameToIdCacheService';
+import { GovernanceGroupNameToIdCacheService } from '../../services/cache/GovernanceGroupNameToIdCacheService';
+import { CSV_MULTIVALUE_SEPARATOR } from '../../constants';
 
 // List of mandatory headers to update the description of entitlements
 const mandatoryHeadersDescription = ["attributeName", "attributeValue", "displayName", "description", "schema"];
 const mandatoryHeadersOthers = ["attributeName", "attributeValue", "schema"];
-const optionalHeadersOthers = ["requestable", "owner", "privileged"];
+const optionalHeadersOthers = ["requestable", "owner", "privileged", "additionalOwners", "additionalOwnerGovernanceGroup"];
+const OWNER_ID_REGEX = /^[a-f0-9]{32}$/;
 
 
 interface UncorrelatedAccountImportResult {
@@ -29,6 +33,8 @@ interface UncorrelatedAccountImportResult {
 class EntitlementDetailsImporter {
     readonly client: ISCClient;
     readonly csvReader: CSVReader<any>;
+    readonly identityCacheService: IdentityNameToIdCacheService;
+    readonly governanceGroupCacheService: GovernanceGroupNameToIdCacheService;
     readonly result: UncorrelatedAccountImportResult = {
         totalDescription: 0,
         totalDescriptionUpdated: 0,
@@ -51,6 +57,8 @@ class EntitlementDetailsImporter {
     ) {
         this.client = new ISCClient(this.tenantId, this.tenantName);
         this.csvReader = new CSVReader<any>(this.fileUri.fsPath);
+        this.identityCacheService = new IdentityNameToIdCacheService(this.client);
+        this.governanceGroupCacheService = new GovernanceGroupNameToIdCacheService(this.client);
     }
 
     public async importFileWithProgression(): Promise<void> {
@@ -204,6 +212,68 @@ class EntitlementDetailsImporter {
                         this.result.identityNotFound++;
                     }
                 }
+            }
+
+            const additionalOwnersRaw = data.additionalOwners;
+            const additionalOwnerGovernanceGroupRaw = data.additionalOwnerGovernanceGroup;
+            if (isNotEmpty(additionalOwnersRaw) || isNotEmpty(additionalOwnerGovernanceGroupRaw)) {
+                const ownerNames = (additionalOwnersRaw ?? "")
+                    .split(CSV_MULTIVALUE_SEPARATOR)
+                    .map((value: string) => value.trim())
+                    .filter((value: string) => value.length > 0);
+
+                const governanceGroupName = additionalOwnerGovernanceGroupRaw?.trim() ?? "";
+
+                if (governanceGroupName && ownerNames.length > 0) {
+                    this.result.error++;
+                    return;
+                }
+
+                if (ownerNames.length > 10) {
+                    this.result.error++;
+                    return;
+                }
+
+                let additionalOwners: Array<{ type: "IDENTITY" | "GOVERNANCE_GROUP"; id: string; name?: string }> = [];
+                if (governanceGroupName) {
+                    try {
+                        const groupId = await this.governanceGroupCacheService.get(governanceGroupName);
+                        additionalOwners = [{
+                            type: "GOVERNANCE_GROUP",
+                            id: groupId,
+                            name: governanceGroupName
+                        }];
+                    } catch (error) {
+                        this.result.error++;
+                        return;
+                    }
+                } else {
+                    try {
+                        additionalOwners = await Promise.all(ownerNames.map(async (ownerNameOrId: string) => {
+                            if (OWNER_ID_REGEX.test(ownerNameOrId)) {
+                                return {
+                                    type: "IDENTITY",
+                                    id: ownerNameOrId
+                                };
+                            }
+                            const ownerId = await this.identityCacheService.get(ownerNameOrId);
+                            return {
+                                type: "IDENTITY",
+                                id: ownerId,
+                                name: ownerNameOrId
+                            };
+                        }));
+                    } catch (error) {
+                        this.result.identityNotFound++;
+                        return;
+                    }
+                }
+
+                payload.push({
+                    "op": "replace",
+                    "path": "/additionalOwners",
+                    "value": additionalOwners
+                });
             }
 
             if (payload.length === 0) {


### PR DESCRIPTION
Implemented bulk CSV support for multi-owner Roles, Access Profiles, and Entitlements.

Changes:
- Added CSV columns: `additionalOwners` (semicolon-separated identities, max 10) and `additionalOwnerGovernanceGroup` (single governance group name, mutually exclusive).
- Importers resolve identities/governance group IDs and send `additionalOwners` in create/patch payloads.
- Exporters include `additionalOwners` or `additionalOwnerGovernanceGroup` based on the data returned.

Docs/snippets:
- README updated with new CSV columns and Entitlement Details section.
- Access Profile + Role snippets updated with `additionalOwners` placeholders.

Files touched:
- src/commands/access-profile/AccessProfileImporter.ts
- src/commands/access-profile/ExportAccessProfiles.ts
- src/commands/role/RoleImporter.ts
- src/commands/role/ExportRoles.ts
- src/commands/source/importEntitlementDetails.ts
- src/commands/source/exportEntitlementDetails.ts
- README.md
- snippets/access-profile.json
- snippets/role.json

Note: Entitlement bulk import uses the Entitlement Details CSV path (metadata update), not the aggregation import.