### PR TITLE
fix transforms pagination boundary and webview tsconfig diagnostics

### DIFF
--- a/src/campaign-webview/app/tsconfig.json
+++ b/src/campaign-webview/app/tsconfig.json
@@ -1,21 +1,18 @@
 {
-  "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
-    /**
-     * Typecheck JS in `.svelte` and `.js` files by default.
-     * Disable checkJs if you'd like to use dynamic types in JS.
-     * Note that setting allowJs false does not prevent the use
-     * of JS in `.svelte` files.
-     */
     "allowJs": true,
     "checkJs": true,
     "isolatedModules": true,
-    "moduleDetection": "force"
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "types": ["svelte", "vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "vite.config.ts"]
 }

--- a/src/services/ISCClient.ts
+++ b/src/services/ISCClient.ts
@@ -405,8 +405,39 @@ export class ISCClient {
 		console.log("> getTransforms");
 		const apiConfig = await this.getApiConfiguration();
 		const api = new TransformsApi(apiConfig, undefined, this.getAxiosWithInterceptors());
-		const result = await Paginator.paginate(api, api.listTransforms);
-		const transforms = result.data;
+		const transforms: TransformRead[] = [];
+		let offset = 0;
+		let totalCount: number | undefined;
+
+		while (true) {
+			const response = await api.listTransforms({
+				offset,
+				limit: DEFAULT_PAGINATION,
+				count: totalCount === undefined
+			});
+
+			if (totalCount === undefined) {
+				const totalCountHeader = response.headers[TOTAL_COUNT_HEADER];
+				const totalCountValue = Array.isArray(totalCountHeader) ? totalCountHeader[0] : totalCountHeader;
+				const parsedTotalCount = Number(totalCountValue);
+				if (Number.isFinite(parsedTotalCount) && parsedTotalCount >= 0) {
+					totalCount = parsedTotalCount;
+				}
+			}
+
+			const page = response.data;
+			if (!page || page.length === 0) {
+				break;
+			}
+
+			transforms.push(...page);
+			offset += page.length;
+
+			if ((totalCount !== undefined && offset >= totalCount) || page.length < DEFAULT_PAGINATION) {
+				break;
+			}
+		}
+
 		if (transforms !== undefined && transforms instanceof Array) {
 			transforms.sort(compareByName);
 		}


### PR DESCRIPTION
Changes
Updated transform retrieval logic in _ISCClient.ts_ to use explicit pagination with safe stop conditions:
Read total count from response header on first call
Stop when fetched count reaches total count
Also stop on empty or short page
Updated webview TypeScript config in _tsconfig.json_:
Removed external extends dependency
Removed references entry to node tsconfig
Added self-contained compilerOptions for local typechecking

Behavior Before
Expanding Transforms could fail at 250 items with "Specified offset is invalid."
VS Code showed tsconfig errors in campaign webview project.

Behavior After
Transform listing no longer sends invalid boundary offset request at 250.
Campaign webview tsconfig diagnostics are resolved with local, consistent configuration.