### PR TITLE
added custom auth url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ This changelog is following the recommended format by [keepachangelog](https://k
 
 ### Removed
 
+## [1.3.29] - 2026-05-08
+
+### Added 
+
+- Extension parameter : `sP-Config.auth.baseUrl` to specify which auth URL to use. Default value is `api.identitynow.com`. The user can also change it to `login.sailpoint.com`
+
+### Changed
+
+- Function that loads the auth URL to use the `sP-Config.auth.baseUrl` parameter if the tenant name is the tenant itself or `<tenant>.api.identitynow.com`.
+
 ## [1.3.28] - 2026-05-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@ The extension supports the following settings:
   - Default value: `%x/exportedObjects`
 - `vscode-sailpoint-identitynow.sP-Config.multipleFiles.filename`: Define the pattern for the SP-Config filename as multiple files for multiple resources. It will be concatenated to the export folder. These filenames are not confirmed.
   - Default value: `%o/%S.json`
+- `vscode-sailpoint-identitynow.sP-Config.auth.baseUrl` : Define the default base URL for authentication. It will be used during the access token loading. The values are for non-vanity urls and can be : `api.identitynow.com`  or `login.sailpoint.com`
+  - Default value : `login.sailpoint.com`
 - `vscode-sailpoint-identitynow.export.forms.filename`: Define the pattern to export forms from a tenant
   - Default value: `%x/Forms/Forms-%t-%y%M%d-%h%m%s.json`
 - `vscode-sailpoint-identitynow.export.form.filename`: Define the pattern to export a single form from a tenant
@@ -622,6 +624,11 @@ The patterns defined above use the following tokens:
 ## Release Notes
 
 ### Unreleased
+
+### 1.3.29
+
+- Added extension parameter : `sP-Config.auth.baseUrl` to specify which auth URL to use. Default value is `api.identitynow.com`. The user can also change it to `login.sailpoint.com`
+- Update the function that loads the auth URL to use the `sP-Config.auth.baseUrl` parameter if the tenant name is the tenant itself or `<tenant>.api.identitynow.com`.
 
 ### 1.3.28
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sailpoint-identitynow",
   "displayName": "SailPoint Identity Security Cloud",
   "description": "Customize SailPoint Identity Security Cloud",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "publisher": "yannick-beot-sp",
   "icon": "resources/isc.png",
   "bugs": {
@@ -1785,6 +1785,10 @@
         "vscode-sailpoint-identitynow.sP-Config.multipleFiles.filename": {
           "type": "string",
           "default": "%o/%S.json"
+        },
+        "vscode-sailpoint-identitynow.sP-Config.auth.baseUrl": {
+          "type": "string",
+          "default": "api.identitynow.com"
         },
         "vscode-sailpoint-identitynow.export.forms.filename": {
           "type": "string",

--- a/src/configurationConstants.ts
+++ b/src/configurationConstants.ts
@@ -13,6 +13,8 @@ export const SPCONFIG_SINGLE_FILE_CONF = "sP-Config.singleFile.filename";
 export const SPCONFIG_MULTIPLE_FILES_FOLDER_CONF = "sP-Config.multipleFiles.folder";
 export const SPCONFIG_MULTIPLE_FILES_FILENAME_CONF = "sP-Config.multipleFiles.filename";
 
+export const AUTH_BASE_URL = "sP-Config.auth.baseUrl"
+
 export const TREEVIEW_PAGINATION = "treeView.pagination";
 
 

--- a/src/utils/EndpointUtils.ts
+++ b/src/utils/EndpointUtils.ts
@@ -1,3 +1,4 @@
+import * as configuration from '../configurationConstants';
 import { Uri } from "vscode";
 export class EndpointUtils {
 
@@ -14,8 +15,21 @@ export class EndpointUtils {
         return baseApiUrl;
     }
 
+    public static getAuthUrl(tenantName: string): string {
+        let baseAuthUrl = `https://${tenantName}.${configuration.AUTH_BASE_URL}`;
+        
+        if (tenantName.indexOf('.') > 0) { 
+            if (tenantName.includes('.identitynow.com')){
+                baseAuthUrl = tenantName.replace(/([a-z0-9][a-z0-9-]+)\.(.*)/, "https://$1.") + `${configuration.AUTH_BASE_URL}`;
+            }else{
+                baseAuthUrl = this.getBaseUrl(tenantName);
+            }
+        }
+        return baseAuthUrl;
+    }
+
     public static getAccessTokenUrl(tenantName: string): string {
-        const baseApiUrl = this.getBaseUrl(tenantName);
+        const baseApiUrl = this.getAuthUrl(tenantName);
         return baseApiUrl + '/oauth/token';
     }
 


### PR DESCRIPTION
Some of our clients have issues with the auth `api.identitynow.com` and only `login.sailpoint.com` works so we have added the custom parameter and update the auth function to be able to load that parameter. 

This won't impact the existing configurations but for clients using `login.sailpoint.com`  for auth it will fix the `authentication failed` error.